### PR TITLE
update nan dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "lfsr": "0.0.3",
         "medooze-event-emitter": "^1.2.0",
-        "nan": "^2.18.0",
+        "nan": "^2.22.2",
         "semantic-sdp": "^3.31.1",
         "uuid": "^3.3.2"
     },
@@ -63,7 +63,6 @@
         "lib/*",
         "package.json",
         "tsconfig.json",
-        "build/src",
         "dist",
         "binding.gyp",
         "README.md",


### PR DESCRIPTION
This PR updates `nan` from v2.18.0 to v2.22.2

These are the release notes from versions since then:
```
2.22.2 Feb 26 2025
Bugfix: Fix version guard for ScriptOrigin constructors (#989) 053239d73702ac11fa0c3c438f85c1409f960f89
2.22.1 Feb 21 2025
Build: Fix compatibility with Python >= 3.12 (#987) b5d90f15730b620fb6cc4fed079674740424539a
2.22.0 Oct 11 2024
Feature: replace SetAccessor -> SetNativeDataProperty (#977) 6bd62c9a0004339d5d1e18a945c84929d0f6b808
2.21.0 Oct 10 2024
Feature: Support for node version 20.17.0 (#976) a7df36eda8a7fe8581c00a18590f5e4faafca7ae
2.20.0 Jun 12 2024
Feature: fix removal of v8::CopyablePersistent (#970) 5805ca5c4c2eef9a65316b68741e29f4825c511f
2.19.0 Mar 6 2024
Feature: Fix builds for Electron 29 (#966) 1b630ddb3412cde35b64513662b440f9fd71e1ff
2.18.0 Sep 12 2023
Feature: Cast v8::Object::GetInternalField() return value to v8::Value (#956) bdfee1788239f735b67fe6b46b1439da755e9b62
```