### PR TITLE
Build srtp without LTO

### DIFF
--- a/external/srtp/libsrtp.gyp
+++ b/external/srtp/libsrtp.gyp
@@ -132,7 +132,6 @@
     {
       'target_name': 'libsrtp',
       'type': 'static_library',
-      'cflags': ['-flto'],
       'sources': [
         # includes
         'lib/include/srtp.h',


### PR DESCRIPTION
This is a workaround to maybe get it to build on Nix.