### PR TITLE
Make MEDOOZE_TRACING a compile-time switch

### DIFF
--- a/src/media-server.i
+++ b/src/media-server.i
@@ -103,14 +103,13 @@ using Persistent = Nan::Persistent<T,NonCopyablePersistentTraits<T>>;
 %include "FrameDispatchCoordinator.i"
 
 %init %{
-	auto tracingVar = getenv("MEDOOZE_TRACING");
-	if (tracingVar && std::string(tracingVar) == "1") {
-		perfetto::TracingInitArgs args;
-		//args.backends |= perfetto::kInProcessBackend;
-		args.backends |= perfetto::kSystemBackend;
-		perfetto::Tracing::Initialize(args);
-		MedoozeTrackEventRegister();
-	}
+#ifdef MEDOOZE_TRACING
+	perfetto::TracingInitArgs args;
+	//args.backends |= perfetto::kInProcessBackend;
+	args.backends |= perfetto::kSystemBackend;
+	perfetto::Tracing::Initialize(args);
+	MedoozeTrackEventRegister();
+#endif
 
 	AesGcmSrtpBackend_Register();
 

--- a/src/media-server_wrap.cxx
+++ b/src/media-server_wrap.cxx
@@ -19498,14 +19498,13 @@ void SWIGV8_INIT (SWIGV8_OBJECT exports_obj, SWIGV8_VALUE /*module*/, v8::Local<
   SWIG_InitializeModule(context);
 
 
-	auto tracingVar = getenv("MEDOOZE_TRACING");
-	if (tracingVar && std::string(tracingVar) == "1") {
-		perfetto::TracingInitArgs args;
-		//args.backends |= perfetto::kInProcessBackend;
-		args.backends |= perfetto::kSystemBackend;
-		perfetto::Tracing::Initialize(args);
-		MedoozeTrackEventRegister();
-	}
+#ifdef MEDOOZE_TRACING
+	perfetto::TracingInitArgs args;
+	//args.backends |= perfetto::kInProcessBackend;
+	args.backends |= perfetto::kSystemBackend;
+	perfetto::Tracing::Initialize(args);
+	MedoozeTrackEventRegister();
+#endif
 
 	AesGcmSrtpBackend_Register();
 


### PR DESCRIPTION
This follows upstream and should avoid compilation failures if not defined.